### PR TITLE
autobuild exports for windows shared lib

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ cmake ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_POSITION_INDEPENDENT_CODE=1 ^
     -DBUILD_SHARED_LIBS=1 ^
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=1 ^
     ..
 
 cmake --build . --config Release


### PR DESCRIPTION
see https://cmake.org/cmake/help/v3.4/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html

lemon doesn't export anything, hence on windows no import library is build.

with the change, cmake automatically exports all symbols.