### PR TITLE
set build configuration explicitly on win

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,8 @@
 mkdir build
 cd build
 
+set CONFIGURATION="Release"
+
 cmake ^
     -G "%CMAKE_GENERATOR%" ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
@@ -8,17 +10,18 @@ cmake ^
     -DCMAKE_POSITION_INDEPENDENT_CODE=1 ^
     -DBUILD_SHARED_LIBS=1 ^
     -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=1 ^
+    -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
     ..
 
 if errorlevel 1 exit 1
 
-cmake --build . --config Release
+cmake --build . --config %CONFIGURATION%
 
 if errorlevel 1 exit 1
 
-cmake --build . --config Release --target error_test
+cmake --build . --config %CONFIGURATION% --target error_test
 if errorlevel 1 exit 1
-cmake --build . --config Release --target bfs_test
+cmake --build . --config %CONFIGURATION% --target bfs_test
 if errorlevel 1 exit 1
 
 ctest -R error_test
@@ -26,6 +29,6 @@ if errorlevel 1 exit 1
 ctest -R bfs_test
 if errorlevel 1 exit 1
 
-cmake --build . --config Release --target install
+cmake --build . --config %CONFIGURATION% --target install
 
 if errorlevel 1 exit 1


### PR DESCRIPTION
Last PR to your PR before opening up my own. This build works now on my machine with the same generator as on Azure. So hopes are high!

currently `cmake --build` is used passing the configuration via `--config`. This is not supported by all generators, namely by the one currently used on Azure (NMake Makefiles). In order to stay somehow agnostic to the generator this commit specifies build configuration during cmake config phase already.